### PR TITLE
feat: support left/right modifier hotkeys

### DIFF
--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -17,34 +17,81 @@ func L(_ en: String, _ zh: String) -> String {
 
 enum HotkeyModifier: String, Codable, CaseIterable {
     case control = "Control"
+    case leftControl = "LeftControl"
+    case rightControl = "RightControl"
     case option  = "Option"
+    case leftOption = "LeftOption"
+    case rightOption = "RightOption"
     case command = "Command"
+    case leftCommand = "LeftCommand"
+    case rightCommand = "RightCommand"
     case shift   = "Shift"
+    case leftShift = "LeftShift"
+    case rightShift = "RightShift"
 
     var symbol: String {
         switch self {
         case .control: "⌃"
+        case .leftControl: "⌃L"
+        case .rightControl: "⌃R"
         case .option:  "⌥"
+        case .leftOption: "⌥L"
+        case .rightOption: "⌥R"
         case .command: "⌘"
+        case .leftCommand: "⌘L"
+        case .rightCommand: "⌘R"
         case .shift:   "⇧"
+        case .leftShift: "⇧L"
+        case .rightShift: "⇧R"
         }
     }
 
     var label: String {
         switch self {
         case .control: L("⌃ Control", "⌃ Control")
+        case .leftControl: L("⌃ Left Control", "⌃ 左 Control")
+        case .rightControl: L("⌃ Right Control", "⌃ 右 Control")
         case .option:  L("⌥ Option",  "⌥ Option")
+        case .leftOption: L("⌥ Left Option", "⌥ 左 Option")
+        case .rightOption: L("⌥ Right Option", "⌥ 右 Option")
         case .command: L("⌘ Command", "⌘ Command")
+        case .leftCommand: L("⌘ Left Command", "⌘ 左 Command")
+        case .rightCommand: L("⌘ Right Command", "⌘ 右 Command")
         case .shift:   L("⇧ Shift",   "⇧ Shift")
+        case .leftShift: L("⇧ Left Shift", "⇧ 左 Shift")
+        case .rightShift: L("⇧ Right Shift", "⇧ 右 Shift")
         }
     }
 
-    var flag: NSEvent.ModifierFlags {
+    var baseFlag: NSEvent.ModifierFlags {
         switch self {
-        case .control: .control
-        case .option:  .option
-        case .command: .command
-        case .shift:   .shift
+        case .control, .leftControl, .rightControl: .control
+        case .option, .leftOption, .rightOption: .option
+        case .command, .leftCommand, .rightCommand: .command
+        case .shift, .leftShift, .rightShift: .shift
+        }
+    }
+
+    var keyCode: UInt16? {
+        switch self {
+        case .control, .option, .command, .shift:
+            return nil
+        case .leftControl:
+            return 59
+        case .rightControl:
+            return 62
+        case .leftOption:
+            return 58
+        case .rightOption:
+            return 61
+        case .leftCommand:
+            return 55
+        case .rightCommand:
+            return 54
+        case .leftShift:
+            return 56
+        case .rightShift:
+            return 60
         }
     }
 }
@@ -1141,6 +1188,8 @@ final class ColiASRService: @unchecked Sendable {
 
 @MainActor
 final class HotkeyMonitor {
+    private static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+
     private let modifier: HotkeyModifier
     private let triggerMode: TriggerMode
     private let onToggle: () -> Void
@@ -1186,10 +1235,17 @@ final class HotkeyMonitor {
     }
 
     private func handle(event: NSEvent) {
-        let keyPressed = event.modifierFlags.contains(modifier.flag)
-        // Build "other modifier" set: all standard modifiers except the selected one
+        if let watchedKeyCode = modifier.keyCode {
+            handleSpecificModifier(event: event, watchedKeyCode: watchedKeyCode)
+        } else {
+            handleGenericModifier(event: event)
+        }
+    }
+
+    private func handleGenericModifier(event: NSEvent) {
+        let keyPressed = event.modifierFlags.contains(modifier.baseFlag)
         var others: NSEvent.ModifierFlags = [.shift, .option, .command, .control, .function]
-        others.remove(modifier.flag)
+        others.remove(modifier.baseFlag)
         let hasOtherModifier = !event.modifierFlags.intersection(others).isEmpty
 
         if keyPressed && !hasOtherModifier {
@@ -1201,29 +1257,58 @@ final class HotkeyMonitor {
             if let downAt = keyDownAt {
                 let elapsed = Date().timeIntervalSince(downAt)
                 let isQuickRelease = elapsed < 0.3 && !otherKeyPressed && !hasOtherModifier
-
-                switch triggerMode {
-                case .singleTap:
-                    if isQuickRelease { onToggle() }
-
-                case .doubleTap:
-                    if isQuickRelease {
-                        if let firstTap = firstTapAt {
-                            if Date().timeIntervalSince(firstTap) < 0.5 {
-                                onToggle()
-                                firstTapAt = nil
-                            } else {
-                                // Too slow — treat this tap as the new first tap
-                                firstTapAt = Date()
-                            }
-                        } else {
-                            firstTapAt = Date()
-                        }
-                    }
-                }
+                handleRelease(isQuickRelease: isQuickRelease)
             }
             keyDownAt = nil
             otherKeyPressed = false
+        }
+    }
+
+    private func handleSpecificModifier(event: NSEvent, watchedKeyCode: UInt16) {
+        var otherFlags: NSEvent.ModifierFlags = [.shift, .option, .command, .control, .function]
+        otherFlags.remove(modifier.baseFlag)
+        let hasOtherModifier = !event.modifierFlags.intersection(otherFlags).isEmpty
+
+        if event.keyCode == watchedKeyCode {
+            if keyDownAt == nil {
+                let keyPressed = event.modifierFlags.contains(modifier.baseFlag)
+                if keyPressed && !hasOtherModifier {
+                    keyDownAt = Date()
+                    otherKeyPressed = false
+                }
+            } else if let downAt = keyDownAt {
+                let elapsed = Date().timeIntervalSince(downAt)
+                let isQuickRelease = elapsed < 0.3 && !otherKeyPressed && !hasOtherModifier
+                handleRelease(isQuickRelease: isQuickRelease)
+                keyDownAt = nil
+                otherKeyPressed = false
+            }
+            return
+        }
+
+        if keyDownAt != nil && Self.modifierKeyCodes.contains(event.keyCode) {
+            otherKeyPressed = true
+        }
+    }
+
+    private func handleRelease(isQuickRelease: Bool) {
+        guard isQuickRelease else { return }
+
+        switch triggerMode {
+        case .singleTap:
+            onToggle()
+
+        case .doubleTap:
+            if let firstTap = firstTapAt {
+                if Date().timeIntervalSince(firstTap) < 0.5 {
+                    onToggle()
+                    firstTapAt = nil
+                } else {
+                    firstTapAt = Date()
+                }
+            } else {
+                firstTapAt = Date()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add left/right variants for Control, Option, Command, and Shift hotkeys
- keep the existing generic modifier options unchanged for backward compatibility
- update the hotkey monitor to distinguish physical modifier keys via `flagsChanged` key codes

## Why
TypeNo currently treats modifiers like `Option` as a logical flag, so it cannot bind only the right-side key. This makes setups like `Right Option` impossible even though they are ideal for users who want a less busy hotkey.

## Test Plan
- [x] Build with `swift build -c release`
- [x] Verify existing generic modifier options still deserialize from `UserDefaults`
- [x] Verify the menu now exposes left/right modifier choices for hotkeys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hotkey detection logic by keying off `flagsChanged` `keyCode` for left/right modifiers, which could affect hotkey reliability across keyboard layouts or macOS versions.
> 
> **Overview**
> Adds left/right-specific hotkey options for `Control`, `Option`, `Command`, and `Shift` while keeping the existing generic modifiers for backward compatibility.
> 
> Updates `HotkeyMonitor` to distinguish physical modifier keys using `flagsChanged` `event.keyCode`, refactoring tap/double-tap handling into separate generic vs specific-modifier paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec5f75de5ef79f52896b415b49615ad2ab486d92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->