### PR TITLE
Support Esc to cancel current recording or transcription

### DIFF
--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -418,6 +418,7 @@ final class AppState: ObservableObject {
     }
 
     func cancel() {
+        let targetApp = previousApp
         recordingTimer?.invalidate()
         recordingTimer = nil
         recorder.cancel()
@@ -427,8 +428,12 @@ final class AppState: ObservableObject {
         }
         currentRecordingURL = nil
         transcript = ""
+        previousApp = nil
         phase = .idle
         onOverlayRequest?(false)
+        if let targetApp {
+            targetApp.activate()
+        }
     }
 
     func showPermissions(_ missing: Set<PermissionKind>) {
@@ -506,6 +511,8 @@ final class AppState: ObservableObject {
             phase = .done(transcript)
             onOverlayRequest?(true)
             confirmInsert()
+        } catch is CancellationError {
+            // User canceled the current transcription with Esc.
         } catch TypeNoError.coliNotInstalled {
             showMissingColi()
         } catch {
@@ -578,6 +585,8 @@ final class AppState: ObservableObject {
             NSPasteboard.general.setString(transcript, forType: .string)
             try? await Task.sleep(for: .seconds(2))
             cancel()
+        } catch is CancellationError {
+            // User canceled the current transcription with Esc.
         } catch TypeNoError.coliNotInstalled {
             showMissingColi()
         } catch {
@@ -838,10 +847,14 @@ final class ColiASRService: @unchecked Sendable {
 
     private var currentProcess: Process?
     private let processLock = NSLock()
+    private var currentProcessWasCancelled = false
 
     func cancelCurrentProcess() {
         processLock.lock()
         let proc = currentProcess
+        if proc != nil {
+            currentProcessWasCancelled = true
+        }
         currentProcess = nil
         processLock.unlock()
         if let proc, proc.isRunning {
@@ -911,6 +924,7 @@ final class ColiASRService: @unchecked Sendable {
                     }
 
                     self?.processLock.lock()
+                    self?.currentProcessWasCancelled = false
                     self?.currentProcess = process
                     self?.processLock.unlock()
 
@@ -937,10 +951,15 @@ final class ColiASRService: @unchecked Sendable {
                     stderrHandle.readabilityHandler = nil
 
                     self?.processLock.lock()
+                    let wasCancelled = self?.currentProcessWasCancelled ?? false
+                    self?.currentProcessWasCancelled = false
                     self?.currentProcess = nil
                     self?.processLock.unlock()
 
                     guard process.terminationReason != .uncaughtSignal else {
+                        if wasCancelled {
+                            throw CancellationError()
+                        }
                         throw TypeNoError.transcriptionFailed("Transcription timed out")
                     }
 
@@ -1471,36 +1490,65 @@ extension StatusItemController: NSWindowDelegate {
 // MARK: - Overlay Panel
 
 @MainActor
+final class EscapeAwarePanel: NSPanel {
+    var onEscape: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {
+            onEscape?()
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        onEscape?()
+    }
+}
+
+@MainActor
 final class OverlayPanelController {
-    private let panel: NSPanel
-    private let hostingView: NSHostingView<OverlayView>
+    private let hudPanel: NSPanel
+    private let capturePanel: EscapeAwarePanel
+    private let hudHostingView: NSHostingView<OverlayView>
+    private let captureHostingView: NSHostingView<OverlayView>
     private let appState: AppState
 
     init(appState: AppState) {
         self.appState = appState
-        let overlayView = OverlayView(appState: appState)
-        hostingView = NSHostingView(rootView: overlayView)
+        hudHostingView = NSHostingView(rootView: OverlayView(appState: appState))
+        captureHostingView = NSHostingView(rootView: OverlayView(appState: appState))
 
-        panel = NSPanel(
+        hudPanel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
+        capturePanel = EscapeAwarePanel(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
 
-        panel.isFloatingPanel = true
-        panel.level = .statusBar
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.hidesOnDeactivate = false
-        panel.contentView = hostingView
+        configure(panel: hudPanel, contentView: hudHostingView)
+        configure(panel: capturePanel, contentView: captureHostingView)
+        capturePanel.onEscape = { [weak appState] in
+            appState?.onCancel?()
+        }
     }
 
     func show() {
-        hostingView.invalidateIntrinsicContentSize()
-        let idealSize = hostingView.fittingSize
+        let activePanel = panel(for: appState.phase)
+        let activeHostingView = hostingView(for: appState.phase)
+        let inactivePanel = inactivePanel(for: appState.phase)
+
+        activeHostingView.invalidateIntrinsicContentSize()
+        let idealSize = activeHostingView.fittingSize
         let width = max(idealSize.width, 240)
         let height = max(idealSize.height, 44)
 
@@ -1525,15 +1573,56 @@ final class OverlayPanelController {
                 y = frame.minY + 48
             }
 
-            panel.setFrame(NSRect(x: x, y: y, width: width, height: height), display: true)
+            activePanel.setFrame(NSRect(x: x, y: y, width: width, height: height), display: true)
         } else {
-            panel.setContentSize(NSSize(width: width, height: height))
+            activePanel.setContentSize(NSSize(width: width, height: height))
         }
-        panel.orderFrontRegardless()
+
+        if shouldCaptureKeyboard(for: appState.phase) {
+            NSApp.activate(ignoringOtherApps: true)
+            capturePanel.makeKeyAndOrderFront(nil)
+            capturePanel.makeFirstResponder(capturePanel.contentView)
+        } else {
+            activePanel.orderFrontRegardless()
+        }
+        inactivePanel.orderOut(nil)
     }
 
     func hide() {
-        panel.orderOut(nil)
+        hudPanel.orderOut(nil)
+        capturePanel.orderOut(nil)
+    }
+
+    private func shouldCaptureKeyboard(for phase: AppPhase) -> Bool {
+        switch phase {
+        case .recording, .transcribing:
+            true
+        default:
+            false
+        }
+    }
+
+    private func configure(panel: NSPanel, contentView: NSView) {
+        panel.isFloatingPanel = true
+        panel.level = .statusBar
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.contentView = contentView
+    }
+
+    private func panel(for phase: AppPhase) -> NSPanel {
+        shouldCaptureKeyboard(for: phase) ? capturePanel : hudPanel
+    }
+
+    private func hostingView(for phase: AppPhase) -> NSHostingView<OverlayView> {
+        shouldCaptureKeyboard(for: phase) ? captureHostingView : hudHostingView
+    }
+
+    private func inactivePanel(for phase: AppPhase) -> NSPanel {
+        shouldCaptureKeyboard(for: phase) ? hudPanel : capturePanel
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds `Esc` as a cancel shortcut for the current voice input flow.

Users can now press `Esc` to cancel:
- the current recording
- the current transcription

This improves the retry experience when the speaker wants to restart due to unclear phrasing, noise, or interruptions.

Fixes [#15](https://github.com/marswaveai/TypeNo/issues/15)

## What Changed

- Added `Esc` handling for the active voice input flow
- Supported cancel during both `recording` and `transcribing` states
- Ensured cancel cleans up the in-progress recording/transcription state
- Restored focus back to the previous app after cancel
- Split overlay behavior so only recording/transcribing uses the key-capable cancel panel
- Kept other overlay states as non-activating HUDs to avoid broader focus regressions

## Behavior

Before:
- Users could stop recording with the existing trigger
- There was no direct keyboard way to abort a bad attempt once started

After:
- Press `Esc` while recording to discard the current recording
- Press `Esc` while transcribing to cancel the current transcription
- The app returns to idle cleanly without surfacing a false transcription error

## Notes

- This PR is an implementation of the feature request in [issue #15](https://github.com/marswaveai/TypeNo/issues/15)
- The implementation was adjusted to avoid changing all overlays into focus-stealing panels; only the recording/transcribing cancel path uses a key-capable panel