### PR TITLE
Fix recorder configuration safety

### DIFF
--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -791,20 +791,23 @@ final class AudioRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
         let url = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("m4a")
         let session = AVCaptureSession()
-        session.beginConfiguration()
-
-        let input = try AVCaptureDeviceInput(device: microphone)
-        guard session.canAddInput(input) else {
-            throw TypeNoError.couldNotUseMicrophone(microphone.localizedName)
-        }
-        session.addInput(input)
-
         let output = AVCaptureAudioFileOutput()
-        guard session.canAddOutput(output) else {
-            throw TypeNoError.couldNotStartRecording
+
+        do {
+            session.beginConfiguration()
+            defer { session.commitConfiguration() }
+
+            let input = try AVCaptureDeviceInput(device: microphone)
+            guard session.canAddInput(input) else {
+                throw TypeNoError.couldNotUseMicrophone(microphone.localizedName)
+            }
+            session.addInput(input)
+
+            guard session.canAddOutput(output) else {
+                throw TypeNoError.couldNotStartRecording
+            }
+            session.addOutput(output)
         }
-        session.addOutput(output)
-        session.commitConfiguration()
 
         session.startRunning()
         output.startRecording(to: url, outputFileType: .m4a, recordingDelegate: self)
@@ -856,8 +859,8 @@ final class AudioRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     nonisolated func fileOutput(_ output: AVCaptureFileOutput, didStartRecordingTo fileURL: URL, from connections: [AVCaptureConnection]) {}
 
     nonisolated func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: (any Error)?) {
+        let contextID = ObjectIdentifier(output)
         Task { @MainActor in
-            let contextID = ObjectIdentifier(output)
             guard let context = activeContexts[contextID] else { return }
 
             defer {


### PR DESCRIPTION
## Summary

This is a minimal follow-up to #21 that fixes two recorder-safety issues on top of the current `main` branch.

## Changes

- always pair `AVCaptureSession.beginConfiguration()` with `commitConfiguration()` using `defer`
- avoid capturing `AVCaptureFileOutput` across the nonisolated delegate -> `@MainActor` hop, which fixes the Swift 6.3 concurrency compile error

## Why

The current `main` branch can exit `start(using:)` early without calling `commitConfiguration()` if input/output setup fails. Separately, the delegate callback currently captures `output` directly into a `Task { @MainActor in ... }`, which fails under the current toolchain during local builds.

## Verification

- built `dist/TypeNo.app` locally from latest `origin/main`
- verified the universal binary output builds and runs successfully
- kept the change limited to `Sources/Typeno/main.swift`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small changes limited to the audio recorder setup and delegate callback; main impact is on recording start/stop reliability and Swift concurrency compliance.
> 
> **Overview**
> Tightens `AudioRecorder` safety by guaranteeing `AVCaptureSession.beginConfiguration()` is always paired with `commitConfiguration()` via `defer`, even when input/output setup throws.
> 
> Also avoids capturing `AVCaptureFileOutput` across the `nonisolated` delegate callback into the `@MainActor` `Task` by computing `contextID` before the actor hop, fixing Swift 6.3 concurrency build issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 378c093c0267be404e388865c7b5b88152a00642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->