### PR TITLE
Add an option in menu to convert Simplified Chinese to Traditional Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,24 @@ That's it. No windows, no settings, no accounts.
 
 ## Install
 
-### Option 1 — Download the App
+### Install dependencies
+
+- The speech engine
+
+TypeNo uses [coli](https://github.com/marswaveai/coli) for local speech recognition:
+
+```bash
+npm install -g @marswave/coli
+```
+
+- Chinese Conversion
+The speech engine outputs Simplified Chinese by default. The default output is the original AST result. To convert it to Traditional Chinese, use OpenCC.
+
+``` bash
+brew install opencc
+```
+
+### Install this project (Option 1 — Download the App)
 
 - [Download TypeNo for macOS](https://github.com/marswaveai/TypeNo/releases/latest)
 - Download the latest `TypeNo.app.zip`
@@ -32,13 +49,6 @@ That's it. No windows, no settings, no accounts.
 
 TypeNo is signed and notarized by Apple — it should open without any warnings.
 
-### Install the speech engine
-
-TypeNo uses [coli](https://github.com/marswaveai/coli) for local speech recognition:
-
-```bash
-npm install -g @marswave/coli
-```
 
 If Coli is missing, TypeNo will show an in-app setup prompt with the install command.
 
@@ -60,7 +70,7 @@ Some users find that enabling TypeNo in **System Settings → Privacy & Security
 
 ![Accessibility permission fix](assets/accessibility-fix.gif)
 
-### Option 2 — Build from Source
+### Install this project (Option 2 — Build from Source)
 
 ```bash
 git clone https://github.com/marswaveai/TypeNo.git

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,7 +22,24 @@
 
 ## 安装
 
-### 方式一：直接下载
+### 安装依赖
+
+- 语音识别引擎
+
+TypeNo 使用 [coli](https://github.com/marswaveai/coli) 进行本地语音识别：
+
+```bash
+npm install -g @marswave/coli
+```
+
+- 中文繁简转换
+语音引擎默认输出简体中文，默认输出为原始 AST 结果。如需转换为繁体中文，请安装 OpenCC：
+
+```bash
+brew install opencc
+```
+
+### 安装本项目（方式一：直接下载 App）
 
 - [下载 TypeNo for macOS](https://github.com/marswaveai/TypeNo/releases/latest)
 - 下载最新的 `TypeNo.app.zip`
@@ -30,14 +47,6 @@
 - 打开 TypeNo
 
 TypeNo 已通过 Apple 签名和公证，可以直接打开使用。
-
-### 安装语音识别引擎
-
-TypeNo 使用 [coli](https://github.com/marswaveai/coli) 进行本地语音识别：
-
-```bash
-npm install -g @marswave/coli
-```
 
 如果未安装 Coli，TypeNo 会在应用内弹出引导提示。
 
@@ -59,7 +68,7 @@ TypeNo 需要两个一次性授权：
 
 ![辅助功能权限修复](assets/accessibility-fix.gif)
 
-### 方式二：从源码构建
+### 安装本项目（方式二：从源码构建）
 
 ```bash
 git clone https://github.com/marswaveai/TypeNo.git

--- a/README_JP.md
+++ b/README_JP.md
@@ -22,7 +22,24 @@
 
 ## インストール
 
-### 方法 1：アプリをダウンロード
+### 依存関係のインストール
+
+- 音声認識エンジン
+
+TypeNo はローカル音声認識に [coli](https://github.com/marswaveai/coli) を使用します：
+
+```bash
+npm install -g @marswave/coli
+```
+
+- 中国語簡体/繁体変換
+音声エンジンはデフォルトで簡体字中国語を出力します。デフォルトは元の AST 結果です。繁体字に変換するには OpenCC をインストールしてください：
+
+```bash
+brew install opencc
+```
+
+### 本プロジェクトのインストール（方法 1：アプリをダウンロード）
 
 - [TypeNo for macOS をダウンロード](https://github.com/marswaveai/TypeNo/releases/latest)
 - 最新の `TypeNo.app.zip` をダウンロード
@@ -31,15 +48,7 @@
 
 TypeNo は Apple の署名と公証済みです。警告なしでそのまま開けます。
 
-### 音声認識エンジンをインストール
-
-TypeNo はローカル音声認識に [coli](https://github.com/marswaveai/coli) を使用します：
-
-```bash
-npm install -g @marswave/coli
-```
-
-未インストールの場合、アプリ内でガイダンスが表示されます。
+Coli が未インストールの場合、アプリ内でガイダンスが表示されます。
 
 ### 初回起動
 
@@ -59,7 +68,7 @@ TypeNo には一度だけ次の2つの権限が必要です：
 
 ![アクセシビリティ権限の修正](assets/accessibility-fix.gif)
 
-### 方法 2：ソースからビルド
+### 本プロジェクトのインストール（方法 2：ソースからビルド）
 
 ```bash
 git clone https://github.com/marswaveai/TypeNo.git

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -82,6 +82,39 @@ enum TriggerMode: String, Codable, CaseIterable {
     }
 }
 
+enum ChineseConversion: String, Codable, CaseIterable {
+    case none = "None"
+    case s2t = "s2t"
+    case s2tw = "s2tw"
+    case s2hk = "s2hk"
+
+    var label: String {
+        switch self {
+        case .none:
+            return "None"
+        case .s2t:
+            return "Simplified → Traditional (s2t)"
+        case .s2tw:
+            return "Simplified → Traditional (s2tw)"
+        case .s2hk:
+            return "Simplified → Traditional (s2hk)"
+        }
+    }
+
+    var openCCConfigFile: String? {
+        switch self {
+        case .none:
+            return nil
+        case .s2t:
+            return "s2t.json"
+        case .s2tw:
+            return "s2tw.json"
+        case .s2hk:
+            return "s2hk.json"
+        }
+    }
+}
+
 enum MicrophoneSelection: Equatable {
     case automatic
     case specific(String)
@@ -111,6 +144,7 @@ extension UserDefaults {
     private static let modifierKey   = "ai.marswave.typeno.hotkeyModifier"
     private static let triggerKey    = "ai.marswave.typeno.triggerMode"
     private static let microphoneKey = "ai.marswave.typeno.microphone"
+    private static let chineseConversionKey = "ai.marswave.typeno.chineseConversion"
 
     var hotkeyModifier: HotkeyModifier {
         get {
@@ -139,6 +173,15 @@ extension UserDefaults {
                 removeObject(forKey: Self.microphoneKey)
             }
         }
+    }
+
+    var chineseConversion: ChineseConversion {
+        get {
+            guard let raw = string(forKey: Self.chineseConversionKey),
+                  let v = ChineseConversion(rawValue: raw) else { return .none }
+            return v
+        }
+        set { set(newValue.rawValue, forKey: Self.chineseConversionKey) }
     }
 }
 
@@ -538,8 +581,11 @@ final class AppState: ObservableObject {
         phase = .transcribing()
 
         do {
-            let text = try await asrService.transcribe(fileURL: url)            
-            let converted = try ColiASRService.convertToTraditional(text)
+            let text = try await asrService.transcribe(fileURL: url)
+            let converted = try ColiASRService.convertChinese(
+                text,
+                conversion: UserDefaults.standard.chineseConversion
+            )
             transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
@@ -611,7 +657,10 @@ final class AppState: ObservableObject {
 
         do {
             let text = try await asrService.transcribe(fileURL: url)
-            let converted = try ColiASRService.convertToTraditional(text)
+            let converted = try ColiASRService.convertChinese(
+                text,
+                conversion: UserDefaults.standard.chineseConversion
+            )
             transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
@@ -922,7 +971,11 @@ final class ColiASRService: @unchecked Sendable {
         findNpmPath() != nil
     }
 
-    static func convertToTraditional(_ text: String) throws -> String {
+    static func convertChinese(_ text: String, conversion: ChineseConversion) throws -> String {
+        guard let configFile = conversion.openCCConfigFile else {
+            return text
+        }
+
         let openccPaths = [
             "/opt/homebrew/bin/opencc",   // Apple Silicon
             "/usr/local/bin/opencc"       // Intel Mac
@@ -934,8 +987,7 @@ final class ColiASRService: @unchecked Sendable {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: openccPath)
-
-        process.arguments = ["-c", "s2tw.json"]
+        process.arguments = ["-c", configFile]
 
         let stdinPipe = Pipe()
         let stdoutPipe = Pipe()
@@ -959,7 +1011,8 @@ final class ColiASRService: @unchecked Sendable {
         }
 
         let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? text
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? text
     }
 
     /// Auto-install coli via npm. Reports progress via callback.
@@ -1506,6 +1559,7 @@ final class StatusItemController: NSObject {
         static let record = 100
         static let update = 200
         static let microphone = 250
+        static let chineseConversionBase = 275
         static let hotkeyBase = 300
         static let triggerBase = 400
     }
@@ -1560,6 +1614,20 @@ final class StatusItemController: NSObject {
         microphoneItem.tag = MenuTag.microphone
         menu.setSubmenu(makeMicrophoneSubmenu(), for: microphoneItem)
         menu.addItem(microphoneItem)
+
+        // Chinese Conversion sub-menu
+        let conversionItem = NSMenuItem(title: "Chinese Conversion", action: nil, keyEquivalent: "")
+        let conversionSub = NSMenu()
+        let currentConversion = UserDefaults.standard.chineseConversion
+        for (i, option) in ChineseConversion.allCases.enumerated() {
+            let item = NSMenuItem(title: option.label, action: #selector(changeChineseConversion(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = MenuTag.chineseConversionBase + i
+            item.state = option == currentConversion ? .on : .off
+            conversionSub.addItem(item)
+        }
+        menu.setSubmenu(conversionSub, for: conversionItem)
+        menu.addItem(conversionItem)
 
         // Hotkey sub-menu
         let hotkeyItem = NSMenuItem(title: L("Hotkey", "快捷键"), action: nil, keyEquivalent: "")
@@ -1721,6 +1789,13 @@ final class StatusItemController: NSObject {
             UserDefaults.standard.microphoneSelection = .automatic
         }
         refreshMicrophoneSubmenu()
+    }
+
+    @objc private func changeChineseConversion(_ sender: NSMenuItem) {
+        let idx = sender.tag - MenuTag.chineseConversionBase
+        guard let conversion = ChineseConversion.allCases[safe: idx] else { return }
+        UserDefaults.standard.chineseConversion = conversion
+        sender.menu?.items.forEach { $0.state = $0.tag == sender.tag ? .on : .off }
     }
 
     @objc private func changeTriggerMode(_ sender: NSMenuItem) {

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -91,13 +91,13 @@ enum ChineseConversion: String, Codable, CaseIterable {
     var label: String {
         switch self {
         case .none:
-            return "None"
+            return L("None", "无转换")
         case .s2t:
-            return "Simplified → Traditional (s2t)"
+            return L("Simplified → Traditional (s2t)", "简体 → 繁体（标准）")
         case .s2tw:
-            return "Simplified → Traditional (s2tw)"
+            return L("Simplified → Traditional (s2tw)", "简体 → 繁体（台湾）")
         case .s2hk:
-            return "Simplified → Traditional (s2hk)"
+            return L("Simplified → Traditional (s2hk)", "简体 → 繁体（香港）")
         }
     }
 
@@ -1621,7 +1621,7 @@ final class StatusItemController: NSObject {
         menu.addItem(microphoneItem)
 
         // Chinese Conversion sub-menu
-        let conversionItem = NSMenuItem(title: "Chinese Conversion", action: nil, keyEquivalent: "")
+    let conversionItem = NSMenuItem(title: L("Chinese Conversion", "中文转换"), action: nil, keyEquivalent: "")
         let conversionSub = NSMenu()
         let currentConversion = UserDefaults.standard.chineseConversion
         for (i, option) in ChineseConversion.allCases.enumerated() {

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -997,7 +997,12 @@ final class ColiASRService: @unchecked Sendable {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            // If OpenCC cannot be launched, gracefully degrade
+            return text
+        }
 
         if let data = text.data(using: .utf8) {
             stdinPipe.fileHandleForWriting.write(data)

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -1005,6 +1005,21 @@ final class ColiASRService: @unchecked Sendable {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // Read pipe data asynchronously to avoid deadlock when buffer fills up
+        let stdoutBuf = LockedData()
+        let stderrBuf = LockedData()
+        let stdoutHandle = stdoutPipe.fileHandleForReading
+        let stderrHandle = stderrPipe.fileHandleForReading
+
+        stdoutHandle.readabilityHandler = { handle in
+            let data = handle.availableData
+            if !data.isEmpty { stdoutBuf.append(data) }
+        }
+        stderrHandle.readabilityHandler = { handle in
+            let data = handle.availableData
+            if !data.isEmpty { stderrBuf.append(data) }
+        }
+
         do {
             try process.run()
         } catch {
@@ -1019,11 +1034,15 @@ final class ColiASRService: @unchecked Sendable {
 
         process.waitUntilExit()
 
+        // Stop reading handlers
+        stdoutHandle.readabilityHandler = nil
+        stderrHandle.readabilityHandler = nil
+
         guard process.terminationStatus == 0 else {
             return text
         }
 
-        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let data = stdoutBuf.read()
         return String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? text
     }

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -582,10 +582,7 @@ final class AppState: ObservableObject {
 
         do {
             let text = try await asrService.transcribe(fileURL: url)
-            let converted = try ColiASRService.convertChinese(
-                text,
-                conversion: UserDefaults.standard.chineseConversion
-            )
+            let converted = try await convertChineseAsync(text, conversion: UserDefaults.standard.chineseConversion)
             transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
@@ -657,10 +654,7 @@ final class AppState: ObservableObject {
 
         do {
             let text = try await asrService.transcribe(fileURL: url)
-            let converted = try ColiASRService.convertChinese(
-                text,
-                conversion: UserDefaults.standard.chineseConversion
-            )
+            let converted = try await convertChineseAsync(text, conversion: UserDefaults.standard.chineseConversion)
             transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
@@ -680,6 +674,20 @@ final class AppState: ObservableObject {
             showMissingColi()
         } catch {
             showError(error.localizedDescription)
+        }
+    }
+
+    /// Converts Chinese text using OpenCC on a background queue.
+    func convertChineseAsync(_ text: String, conversion: ChineseConversion) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let result = try ColiASRService.convertChinese(text, conversion: conversion)
+                    continuation.resume(returning: result)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
         }
     }
 }

--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -538,8 +538,9 @@ final class AppState: ObservableObject {
         phase = .transcribing()
 
         do {
-            let text = try await asrService.transcribe(fileURL: url)
-            transcript = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let text = try await asrService.transcribe(fileURL: url)            
+            let converted = try ColiASRService.convertToTraditional(text)
+            transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
                 throw TypeNoError.emptyTranscript
@@ -610,7 +611,8 @@ final class AppState: ObservableObject {
 
         do {
             let text = try await asrService.transcribe(fileURL: url)
-            transcript = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let converted = try ColiASRService.convertToTraditional(text)
+            transcript = converted.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard transcript.isEmpty == false else {
                 throw TypeNoError.emptyTranscript
@@ -918,6 +920,46 @@ final class ColiASRService: @unchecked Sendable {
 
     static var isNpmAvailable: Bool {
         findNpmPath() != nil
+    }
+
+    static func convertToTraditional(_ text: String) throws -> String {
+        let openccPaths = [
+            "/opt/homebrew/bin/opencc",   // Apple Silicon
+            "/usr/local/bin/opencc"       // Intel Mac
+        ]
+
+        guard let openccPath = openccPaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+            return text
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: openccPath)
+
+        process.arguments = ["-c", "s2tw.json"]
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+
+        if let data = text.data(using: .utf8) {
+            stdinPipe.fileHandleForWriting.write(data)
+        }
+        try? stdinPipe.fileHandleForWriting.close()
+
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            return text
+        }
+
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? text
     }
 
     /// Auto-install coli via npm. Reports progress via callback.


### PR DESCRIPTION
It seems the Sherpa ASR model was trained only on Simplified Chinese, so I'm converting the output to Traditional Chinese using OpenCC.

I'm new to Swift—if there's a better way to do this, I'm open to suggestions!


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an external `opencc` process step into the transcription path and exposes it via a persisted menu setting, which could impact transcription latency/behavior or fail depending on local OpenCC installation.
> 
> **Overview**
> Adds an optional **Simplified→Traditional Chinese conversion** step to transcription output using OpenCC, applied for both live recordings and file transcription.
> 
> Introduces a persisted `ChineseConversion` setting (with `s2t`/`s2tw`/`s2hk` presets) and a new menu-bar submenu to select it; conversion gracefully falls back to returning the original text if `opencc` is unavailable or fails.
> 
> Updates the EN/CN/JP READMEs to document the new OpenCC dependency and reorganizes install sections accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2335b387809a2510931d2f72ef4e3b579f1ec0cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->