### PR TITLE
feat: add retry mechanism for transcription

### DIFF
--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -1018,6 +1018,25 @@ final class ColiASRService: @unchecked Sendable {
             throw TypeNoError.transcriptionFailed(modelIssue)
         }
 
+        // Retry once on failure (handles transient issues like ffmpeg not found)
+        var lastError: Error?
+        for attempt in 0..<2 {
+            do {
+                return try await runTranscription(fileURL: fileURL, coliPath: coliPath)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                lastError = error
+                if attempt == 0 {
+                    // Brief delay before retry
+                    try? await Task.sleep(for: .milliseconds(500))
+                }
+            }
+        }
+        throw lastError!
+    }
+
+    private func runTranscription(fileURL: URL, coliPath: String) async throws -> String {
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 do {
@@ -1025,7 +1044,7 @@ final class ColiASRService: @unchecked Sendable {
                     process.executableURL = URL(fileURLWithPath: coliPath)
                     process.arguments = ["asr", fileURL.path]
 
-                    // Inherit a proper PATH so node/bun can be found
+                    // Inherit a proper PATH so node/bun/ffmpeg can be found
                     var env = ProcessInfo.processInfo.environment
                     let home = env["HOME"] ?? ""
                     let coliDir = (coliPath as NSString).deletingLastPathComponent


### PR DESCRIPTION
## Summary

- Add automatic retry (once) when transcription fails
- Wait 500ms before retry to handle transient issues
- Cancellation errors are not retried

This handles intermittent failures like ffmpeg not being found due to PATH issues or race conditions.

## Test Plan

- [x] Build app successfully
- [x] Normal transcription still works
- [x] Failed transcription will retry once before showing error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change that only adds a single retry/delay and preserves cancellation behavior; main impact is potentially masking the first underlying error until the second attempt fails.
> 
> **Overview**
> Improves transcription robustness by retrying the Coli `asr` invocation once when `transcribe(fileURL:)` fails, waiting 500ms before the second attempt and *never* retrying `CancellationError`.
> 
> Refactors the actual process execution into `runTranscription(...)` and updates the PATH comment to reflect `ffmpeg` being part of the expected environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be5e2e688c200a70905ac1557ad86fb6e8e98184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->