### PR TITLE
Fix duplicate text rendering in compact overlay

### DIFF
--- a/Sources/Typeno/main.swift
+++ b/Sources/Typeno/main.swift
@@ -2417,39 +2417,6 @@ struct OverlayView: View {
                         .truncationMode(.head)
                 }
             }
-
-            // Text content
-            Group {
-                if case .done(let text) = appState.phase {
-                    Text(text)
-                        .foregroundStyle(.white)
-                        .lineLimit(1)
-                        .truncationMode(.head)
-                } else if case .recording = appState.phase {
-                    if appState.previewTranscript.isEmpty {
-                        Text(L("Listening...", "聆听中..."))
-                            .foregroundStyle(.white.opacity(0.35))
-                            .lineLimit(1)
-                            .truncationMode(.head)
-                    } else {
-                        Text(appState.previewTranscript)
-                            .foregroundStyle(.white.opacity(0.9))
-                            .lineLimit(1)
-                            .truncationMode(.head)
-                    }
-                } else if case .error = appState.phase {
-                    Text(appState.phase.subtitle)
-                        .foregroundStyle(.red.opacity(0.9))
-                        .font(.system(size: 12))
-                        .lineLimit(8)
-                        .fixedSize(horizontal: false, vertical: true)
-                } else {
-                    Text(appState.phase.subtitle)
-                        .foregroundStyle(.white.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.head)
-                }
-            }
             .font(.system(size: 14))
 
             Spacer(minLength: 0)


### PR DESCRIPTION
## Summary

- Remove duplicated `// Text content` Group block in `OverlayView.compactView`, which caused all overlay text to render twice (transcription results, live preview, error messages, update notifications)

## Root Cause

`compactView` contained two identical `Group { ... }` blocks for text content. Both rendered into the same `HStack`, so every `Text` view appeared twice — e.g. saying "测试一下" displayed as "测试一下。测试一下。"

## Fix

Delete the first (duplicate) block, keep the second one which has the `.font(.system(size: 14))` modifier.

Closes #50