### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ TypeNo does one thing: voice → text → paste. No extra UI, no preferences, no
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.com/#marswaveai/TypeNo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.dera.page/#marswaveai/TypeNo&Date)
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -125,7 +125,7 @@ TypeNo 只做一件事：语音 → 文字 → 粘贴。没有多余的 UI，没
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.com/#marswaveai/TypeNo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.dera.page/#marswaveai/TypeNo&Date)
 
 ## 许可证
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -119,7 +119,7 @@ TypeNo がやることはひとつだけ：音声 → テキスト → ペース
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.com/#marswaveai/TypeNo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=marswaveai/TypeNo&type=Date)](https://star-history.dera.page/#marswaveai/TypeNo&Date)
 
 ## ライセンス
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This fix updates the chart URL to a working alternative that uses a different data source, so the chart displays correctly again for English, Chinese, and Japanese READMEs.